### PR TITLE
Add a developers team

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -55,7 +55,9 @@ jobs:
 
       # Execute the plan
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false ${{ github.event.pull_request.number }}.plan
+        run: |
+          mv ${{ github.event.pull_request.number }}.plan tf.plan
+          make apply
 
       - name: Remove plan
         run: python support/s3-plan.py remove ${{ github.event.pull_request.number }}

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -52,7 +52,9 @@ jobs:
 
       # Generates an execution plan for Terraform
       - name: Terraform Plan
-        run: terraform plan -input=false -out=${{ github.event.pull_request.number }}.plan
+        run: |
+          make plan
+          mv tf.plan ${{ github.event.pull_request.number }}.plan
 
       # Upload Terraform Plan
       - name: Upload Terraform Plan

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ init:
 
 .PHONY: plan
 plan: init ## Run terraform plan
-	terraform plan -out=tf.plan
+	terraform plan -var-file=configuration.tfvars --out=tf.plan
 
 
 .PHONY: apply

--- a/configuration.tfvars
+++ b/configuration.tfvars
@@ -1,0 +1,3 @@
+developers = [
+  "akuzminsky"
+]

--- a/membership.tf
+++ b/membership.tf
@@ -1,3 +1,4 @@
-resource "github_membership" "aleks" {
-  username = "akuzminsky"
+resource "github_membership" "infrahouse" {
+  for_each = toset(var.developers)
+  username = each.key
 }

--- a/teams.tf
+++ b/teams.tf
@@ -1,0 +1,15 @@
+resource "github_team" "dev" {
+  name        = "developers"
+  description = "Development Team"
+  privacy     = "closed"
+}
+
+resource "github_team_members" "dev" {
+  team_id = github_team.dev.id
+  dynamic "members" {
+    for_each = toset(var.developers)
+    content {
+      username = members.key
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "developers" {
+  description = "List of members of the developers team. They will be invited to the organization as well."
+  default     = []
+  type        = list(string)
+}


### PR DESCRIPTION
The team members are listed in a variable `developers`.
The developers will be also invited to the InfraHouse organization.

To prevent duplicate code the CI/CD workflows run `make plan/apply`.
