### PR TITLE
Create a PYPI_API_TOKEN secret

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,13 @@
 provider "github" {
   owner = "infrahouse"
 }
+
+provider "aws" {
+  region = "us-west-1"
+  alias  = "uw1"
+}
+
+provider "aws" {
+  region = "us-west-2"
+  alias  = "uw2"
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,11 @@
+resource "aws_secretsmanager_secret" "pypi_api_token" {
+  provider                       = aws.uw1
+  name                           = "PYPI_API_TOKEN"
+  description                    = <<-EOT
+Token for "GitHub Publishing"
+Permissions: Upload packages
+Scope: Entire account (all projects)
+EOT
+  force_overwrite_replica_secret = true
+  recovery_window_in_days        = 0
+}


### PR DESCRIPTION
The Terraform configuration will create only the secret metadata. The
value of the token will be uploaded outside of the github-control.

Later on, this secret will be used to distribute the token to other
repos.
