### PR TITLE
Create PYPI_API_TOKEN in infrahouse-toolkit repo

### DIFF
--- a/secrets.tf
+++ b/secrets.tf
@@ -16,7 +16,7 @@ data "aws_secretsmanager_secret_version" "PYPI_API_TOKEN" {
 }
 
 resource "github_actions_secret" "infrahouse-toolkit-PYPI_API_TOKEN" {
-  repository       = "infrahouse-toolkit"
-  secret_name      = "PYPI_API_TOKEN"
-  plaintext_value  = data.aws_secretsmanager_secret_version.PYPI_API_TOKEN.secret_string
+  repository      = "infrahouse-toolkit"
+  secret_name     = "PYPI_API_TOKEN"
+  plaintext_value = data.aws_secretsmanager_secret_version.PYPI_API_TOKEN.secret_string
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -9,3 +9,14 @@ EOT
   force_overwrite_replica_secret = true
   recovery_window_in_days        = 0
 }
+
+
+data "aws_secretsmanager_secret_version" "PYPI_API_TOKEN" {
+  secret_id = aws_secretsmanager_secret.pypi_api_token.id
+}
+
+resource "github_actions_secret" "infrahouse-toolkit-PYPI_API_TOKEN" {
+  repository       = "infrahouse-toolkit"
+  secret_name      = "PYPI_API_TOKEN"
+  plaintext_value  = data.aws_secretsmanager_secret_version.PYPI_API_TOKEN.secret_string
+}


### PR DESCRIPTION
The secret value is taken from secretsmanager.
If the token needs to be rotated, change the value in the secretsmanager
and run make apply - it will modify the token everywhere where it's
used.
