### PR TITLE
Document AWS IAM policy

### DIFF
--- a/docs/aws-policy.rst
+++ b/docs/aws-policy.rst
@@ -1,0 +1,98 @@
+IAM Policy Configuration
+========================
+
+A GitHub Actions worker that manages a GitHub organization via the `GitHub Control repository <https://github.com/infrahouse8/github-control>`_ needs an AWS credentials with certain permissions.
+By the principle of least privilege the permissions depend on what the worker is supposed to do.
+
+
+Working with Terraform State
+----------------------------
+
+The worker works with the Terraform state in S3. Therefore it need all privileges to read and write to the state file.
+Plus, Terraform itself (AWS provider to be accurate) also tries to list files in a states bucket.
+That yields following requirements:
+
+- ``s3:PutObject``
+- ``s3:GetObject``
+- ``s3:DeleteObject``
+- ``s3:ListBucket``
+
+The repository doesn't use Terraform state locking at the moment.
+If it did, additional privileges would be needed to work with a DynamoDB table.
+
+The following permissions should be scoped to the state bucket.
+If the bucket is shared with other state files, the scope should be reduced to the state file.
+However we find a dedicated bucket for a particular Terraform module more flexible.
+
+Working with Terraform Plan
+---------------------------
+
+In the :ref:`ci-cd-doc-label` document it is explained how and why
+the Terraform state should be saved during a CI stage and available in the CD stage.
+Therefore the AWS user should be able to upload (``s3:PutObject``), download (``s3:GetObject``),
+and delete (``s3:DeleteObject``) the plan file.
+
+We re-use the states bucket to store the plan file, so the permission given for working with the state file will suffice for the plan exchange.
+
+Working with Secrets
+--------------------
+
+Some repositories should have access to certain secrets.
+For example, a Python application repository should have access to the PyPI token so it can publish packages.
+
+Permissions required to work with the Secrets manager:
+
+- ``secretsmanager:CreateSecret``
+- ``secretsmanager:DescribeSecret``
+- ``secretsmanager:GetResourcePolicy``
+- ``secretsmanager:GetSecretValue``
+
+To limit resources the AWS user can read the secrets must start with a prefix ``_github_control__``.
+Then the policy can limit the scope of the permissions rule to :
+
+.. code-block:: json
+
+    "Resource": [
+        "arn:aws:secretsmanager:*:990466748045:secret:_github_control__*"
+    ]
+
+Final IAM Policy
+----------------
+
+.. code-block:: json
+    :caption: arn:aws:iam::990466748045:policy/TFAdminForGitHub
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:DeleteObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::infrahouse-github-state/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::infrahouse-github-state"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "secretsmanager:CreateSecret",
+                    "secretsmanager:DeleteSecret",
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetResourcePolicy",
+                    "secretsmanager:GetSecretValue"
+                ],
+                "Resource": [
+                    "arn:aws:secretsmanager:*:990466748045:secret:_github_control__*"
+                ]
+            }
+        ]
+    }

--- a/docs/cicd.rst
+++ b/docs/cicd.rst
@@ -1,3 +1,5 @@
+.. _ci-cd-doc-label:
+
 Continuous Integration and Deployment (CI/CD)
 =============================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to GitHub Control's documentation!
 
    readme
    cicd
+   aws-policy
 
 
 * :ref:`search`

--- a/repos.tf
+++ b/repos.tf
@@ -3,10 +3,12 @@ locals {
     "infrahouse-toolkit" : {
       description = "InfraHouse Toolkit"
       team_id     = github_team.dev.id
+      type        = "python_app"
     }
     "cookiecutter-github-control" : {
       description = "Template for a GitHub Control repository"
       team_id     = github_team.dev.id
+      type        = "other"
     }
   }
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -24,6 +24,6 @@ resource "github_actions_secret" "pypi_api_token" {
     if local.repos[k]["type"] == "python_app"
   }
   repository      = each.key
-  secret_name     = "PYPI_API_TOKEN"  ## Note: not the same name as in aws_secretsmanager_secret.pypi_api_token
+  secret_name     = "PYPI_API_TOKEN" ## Note: not the same name as in aws_secretsmanager_secret.pypi_api_token
   plaintext_value = data.aws_secretsmanager_secret_version.pypi_api_token.secret_string
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,22 +1,29 @@
 resource "aws_secretsmanager_secret" "pypi_api_token" {
   provider                       = aws.uw1
-  name                           = "PYPI_API_TOKEN"
+  name                           = "_github_control__PYPI_API_TOKEN"
   description                    = <<-EOT
 Token for "GitHub Publishing"
 Permissions: Upload packages
 Scope: Entire account (all projects)
+Created in https://pypi.org/manage/account/
 EOT
   force_overwrite_replica_secret = true
   recovery_window_in_days        = 0
 }
 
 
-data "aws_secretsmanager_secret_version" "PYPI_API_TOKEN" {
+data "aws_secretsmanager_secret_version" "pypi_api_token" {
   secret_id = aws_secretsmanager_secret.pypi_api_token.id
 }
 
-resource "github_actions_secret" "infrahouse-toolkit-PYPI_API_TOKEN" {
-  repository      = "infrahouse-toolkit"
-  secret_name     = "PYPI_API_TOKEN"
-  plaintext_value = data.aws_secretsmanager_secret_version.PYPI_API_TOKEN.secret_string
+
+resource "github_actions_secret" "pypi_api_token" {
+  for_each = {
+    for k in keys(local.repos) :
+    k => local.repos[k]
+    if local.repos[k]["type"] == "python_app"
+  }
+  repository      = each.key
+  secret_name     = "PYPI_API_TOKEN"  ## Note: not the same name as in aws_secretsmanager_secret.pypi_api_token
+  plaintext_value = data.aws_secretsmanager_secret_version.pypi_api_token.secret_string
 }


### PR DESCRIPTION
The IAM policy is needed for an AWS user that manages the Terraform
state and secrets.
