### PR TITLE
Move github-control under a module

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -1,35 +1,18 @@
-resource "github_repository" "github-control" {
-  provider = github.infrahouse8
-
-  name                 = "github-control"
-  description          = "InfraHouse GitHub configuration"
-  has_downloads        = false
-  has_issues           = true
-  has_projects         = false
-  has_wiki             = false
-  vulnerability_alerts = true
-}
-
-resource "github_branch_default" "github-control-main" {
-  provider = github.infrahouse8
-
-  branch     = "main"
-  repository = github_repository.github-control.name
-}
-
-resource "github_branch_protection" "github-control-main" {
-  provider = github.infrahouse8
-
-  pattern       = github_branch_default.github-control-main.branch
-  repository_id = github_repository.github-control.node_id
-
-  required_status_checks {
-    strict = true
-    contexts = [
-      "Terraform Plan",
-    ]
+locals {
+  infrahouse_8_repos = {
+    "github-control" : {
+      description = "InfraHouse GitHub configuration"
+    }
   }
-  required_pull_request_reviews {
-    required_approving_review_count = 0
+}
+
+module "ih_8_repos" {
+  source           = "./modules/local-repo"
+  for_each         = local.infrahouse_8_repos
+  repo_name        = each.key
+  repo_description = each.value["description"]
+
+  providers = {
+    github = github.infrahouse8
   }
 }

--- a/modules/local-repo/repos.tf
+++ b/modules/local-repo/repos.tf
@@ -1,0 +1,28 @@
+resource "github_repository" "repo" {
+  name                 = var.repo_name
+  description          = var.repo_description
+  has_downloads        = false
+  has_issues           = true
+  has_projects         = false
+  has_wiki             = false
+  vulnerability_alerts = true
+}
+
+resource "github_branch_default" "main" {
+  branch     = "main"
+  repository = github_repository.repo.name
+}
+
+resource "github_branch_protection" "main" {
+  pattern       = github_branch_default.main.branch
+  repository_id = github_repository.repo.node_id
+
+  required_status_checks {
+    strict   = true
+    contexts = var.checks
+  }
+
+  required_pull_request_reviews {
+    required_approving_review_count = 0
+  }
+}

--- a/modules/local-repo/terraform.tf
+++ b/modules/local-repo/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/local-repo/variables.tf
+++ b/modules/local-repo/variables.tf
@@ -1,0 +1,15 @@
+variable "repo_description" {
+  description = "The repository description"
+}
+
+variable "repo_name" {
+  description = "Repository short name"
+}
+
+variable "checks" {
+  description = "Required pull request checks"
+  type        = list(string)
+  default = [
+    "Terraform Plan",
+  ]
+}


### PR DESCRIPTION
github-control is the first Terraform live repo. It manages GitHub configuration for InfraHouse and its repos.

However there will be more "bootstrap" repos like github-control.
Next in line is a repo that manages S3 buckects for Terraform states.
