### PR TITLE
Use github-admin role

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -43,7 +43,7 @@ jobs:
       # Download a plan from the approved pull request
       - name: Download plan
         run: |
-          ih-plan download \
+          ih-plan --aws-assume-role-arn arn:aws:iam::990466748045:role/github-admin download \
             plans/${{ github.event.pull_request.number }}.plan \
             tf.plan
 
@@ -63,5 +63,5 @@ jobs:
 
       - name: Remove plan
         run: |
-          ih-plan remove \
+          ih-plan --aws-assume-role-arn arn:aws:iam::990466748045:role/github-admin remove \
             plans/${{ github.event.pull_request.number }}.plan

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -54,12 +54,11 @@ jobs:
       - name: Terraform Plan
         run: |
           make plan
-          ih-plan --aws-assume-role-arn arn:aws:iam::990466748045:role/github-admin \
-            publish ${{ github.repository }} ${{ github.event.pull_request.number }} plan.stdout plan.stderr
+          ih-plan publish ${{ github.repository }} ${{ github.event.pull_request.number }} plan.stdout plan.stderr
 
       # Upload Terraform Plan
       - name: Upload Terraform Plan
         run: |
-          ih-plan upload \
+          ih-plan --aws-assume-role-arn arn:aws:iam::990466748045:role/github-admin upload \
             --key-name=plans/${{ github.event.pull_request.number }}.plan \
             tf.plan

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Terraform Plan
         run: |
           make plan
-          ih-plan publish ${{ github.repository }} ${{ github.event.pull_request.number }} plan.stdout plan.stderr
+          ih-plan --aws-assume-role-arn arn:aws:iam::990466748045:role/github-admin \
+            publish ${{ github.repository }} ${{ github.event.pull_request.number }} plan.stdout plan.stderr
 
       # Upload Terraform Plan
       - name: Upload Terraform Plan

--- a/providers.tf
+++ b/providers.tf
@@ -9,10 +9,23 @@ provider "github" {
 
 provider "aws" {
   region = "us-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::990466748045:role/github-admin"
+  }
+}
+
+provider "aws" {
+  region = "us-west-1"
   alias  = "uw1"
+  assume_role {
+    role_arn = "arn:aws:iam::990466748045:role/github-admin"
+  }
 }
 
 provider "aws" {
   region = "us-west-2"
   alias  = "uw2"
+  assume_role {
+    role_arn = "arn:aws:iam::990466748045:role/github-admin"
+  }
 }

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 boto3 ~= 1.26
-infrahouse-toolkit ~= 1.1, >= 1.1.1
+infrahouse-toolkit ~= 1.2
 pyhcl ~= 0.4
 yamllint ~= 1.29

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,8 +1,11 @@
 terraform {
   backend "s3" {
-    bucket = "infrahouse-github-state"
-    key    = "github.state"
+    bucket   = "infrahouse-github-state"
+    key      = "github.state"
+    region   = "us-west-1"
+    role_arn = "arn:aws:iam::990466748045:role/github-admin"
   }
+
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
In different environments different users/entities may run terraform
plan/apply.

For example, now my local account runs it as well as a user in GitHub
actions.

To ensure consistent permissions, whatever entity runs the terraform
commands it will use the same IAM role `github-admin`.

(no changes in resources are expected)
