### PR TITLE
Create an AWS role as a secret

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -2,6 +2,7 @@ locals {
   infrahouse_8_repos = {
     "github-control" : {
       description = "InfraHouse GitHub configuration"
+      role        = "arn:aws:iam::990466748045:role/github-admin"
     }
     "aws-s3-control" : {
       description = "InfraHouse Terraform State Buckets"
@@ -14,6 +15,7 @@ module "ih_8_repos" {
   for_each         = local.infrahouse_8_repos
   repo_name        = each.key
   repo_description = each.value["description"]
+  role             = contains(keys(each.value), "role") ? each.value["role"] : null
 
   providers = {
     github = github.infrahouse8

--- a/modules/local-repo/repos.tf
+++ b/modules/local-repo/repos.tf
@@ -26,3 +26,10 @@ resource "github_branch_protection" "main" {
     required_approving_review_count = 0
   }
 }
+
+resource "github_actions_secret" "role" {
+  repository      = github_repository.repo.name
+  secret_name     = "AWS_ROLE"
+  plaintext_value = var.role
+  count           = var.role != null ? 1 : 0
+}

--- a/modules/local-repo/variables.tf
+++ b/modules/local-repo/variables.tf
@@ -1,3 +1,11 @@
+variable "checks" {
+  description = "Required pull request checks"
+  type        = list(string)
+  default = [
+    "Terraform Plan",
+  ]
+}
+
 variable "repo_description" {
   description = "The repository description"
 }
@@ -6,10 +14,8 @@ variable "repo_name" {
   description = "Repository short name"
 }
 
-variable "checks" {
-  description = "Required pull request checks"
-  type        = list(string)
-  default = [
-    "Terraform Plan",
-  ]
+variable "role" {
+  description = "AWS role ARN to be saved in a repo secret"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
Following the DRY principle there should be only one place where an
assume role is specified. Unfortunately, the github terraform provider doesn't
allow creating variables. But there are secrets, so I will use them.

The role secret contains an ARN of a role to be passed in CI, CD
workflows.
