### PR TITLE
Create TF templates in both orgs

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -9,14 +9,14 @@ locals {
     }
     aws-control = {
       description       = "InfraHouse Basic AWS configuration"
-      template_repo     = github_repository.terraform-template.name
+      template_repo     = module.ih8_tf_template.name
       tf_admin_username = "tf_aws"
       secrets = {
       }
     }
     aws-s3-control = {
       description       = "InfraHouse Terraform State Buckets"
-      template_repo     = github_repository.terraform-template.name
+      template_repo     = module.ih8_tf_template.name
       tf_admin_username = "tf_s3"
       secrets = {
         AWS_ROLE = "arn:aws:iam::${local.aws_account_id}:role/s3-admin"
@@ -49,9 +49,9 @@ module "ih_8_repos" {
   }
 }
 
-resource "github_repository" "terraform-template" {
-  name = "terraform-template"
-  description = join(
+module "ih8_tf_template" {
+  source = "./modules/repo-template"
+  repo_description = join(
     " ",
     [
       "Template repository for a Terraform project.",
@@ -60,5 +60,9 @@ resource "github_repository" "terraform-template" {
       "This repository will be used as a template to instantiate a new empty Terraform repository."
     ]
   )
-  is_template = true
+  repo_name = "terraform-template"
+  team_id   = github_team.dev.id
+  providers = {
+    github = github.infrahouse8
+  }
 }

--- a/modules/repo-template/outputs.tf
+++ b/modules/repo-template/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = github_repository.repo.name
+}

--- a/modules/repo-template/repos.tf
+++ b/modules/repo-template/repos.tf
@@ -1,0 +1,13 @@
+resource "github_repository" "repo" {
+  name        = var.repo_name
+  description = var.repo_description
+  has_issues  = true
+  visibility  = "public"
+  is_template = true
+}
+
+resource "github_team_repository" "dev" {
+  repository = github_repository.repo.name
+  team_id    = var.team_id
+  permission = "push"
+}

--- a/modules/repo-template/terraform.tf
+++ b/modules/repo-template/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/repo-template/variables.tf
+++ b/modules/repo-template/variables.tf
@@ -1,0 +1,11 @@
+variable "repo_description" {
+  description = "The repository description"
+}
+
+variable "repo_name" {
+  description = "Repository short name"
+}
+
+variable "team_id" {
+  description = "Team identifier that has a push permission"
+}

--- a/repos.tf
+++ b/repos.tf
@@ -16,7 +16,6 @@ locals {
       secrets = {
         AWS_ROLE = "arn:aws:iam::${local.aws_account_id}:role/aws-admin"
       }
-
     }
     "infrahouse-aws-control" : {
       description       = "InfraHouse AWS Infrastructure"
@@ -26,7 +25,6 @@ locals {
       secrets = {
         AWS_ROLE = "arn:aws:iam::${local.aws_account_id}:role/aws-admin"
       }
-
     }
     "cookiecutter-github-control" : {
       description = "Template for a GitHub Control repository"
@@ -58,5 +56,19 @@ module "repos" {
       {}
     )
   )
+}
 
+module "ih_tf_template" {
+  source = "./modules/repo-template"
+  repo_description = join(
+    " ",
+    [
+      "Template repository for a Terraform project.",
+      "This repository is not supposed to become a cookiecutter.",
+      "If you need one - check out https://github.com/infrahouse/cookiecutter-github-control .",
+      "This repository will be used as a template to instantiate a new empty Terraform repository."
+    ]
+  )
+  repo_name = "terraform-template"
+  team_id   = github_team.dev.id
 }


### PR DESCRIPTION
I figures templates will be needed in both infrahouse as well as in
infrahouse8 orgs (latter isn't an org, but whatever).
The diff brings back the template repo to infrahouse8 and creates a new
one in infrahouse. The permissions are fixed, too.
