### PR TITLE
Fix team-id

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -61,7 +61,6 @@ module "ih8_tf_template" {
     ]
   )
   repo_name = "terraform-template"
-  team_id   = github_team.dev.id
   providers = {
     github = github.infrahouse8
   }

--- a/modules/repo-template/repos.tf
+++ b/modules/repo-template/repos.tf
@@ -7,6 +7,7 @@ resource "github_repository" "repo" {
 }
 
 resource "github_team_repository" "dev" {
+  count      = var.team_id != null ? 1 : 0
   repository = github_repository.repo.name
   team_id    = var.team_id
   permission = "push"

--- a/modules/repo-template/variables.tf
+++ b/modules/repo-template/variables.tf
@@ -8,4 +8,5 @@ variable "repo_name" {
 
 variable "team_id" {
   description = "Team identifier that has a push permission"
+  default     = null
 }


### PR DESCRIPTION
team_id is only applicable if a context is an org, not a GitHub user
(like infrahouse8 is).
