### PR TITLE
Remove infrahouse-aws-control

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -18,12 +18,6 @@ locals {
       type        = "terraform_aws"
     }
 
-    "infrahouse-aws-control" : {
-      description = "DEPRECATED: InfraHouse AWS Infrastructure"
-      team_id     = github_team.dev.id
-      type        = "terraform_aws"
-    }
-
     "infrahouse-toolkit" : {
       description = "InfraHouse Toolkit"
       team_id     = github_team.dev.id


### PR DESCRIPTION
There was almost nothing in the repo. twindb stuff moved to the ci-cd
account.

aws itself is managed with aws-control* repos.
