### PR TITLE
Add AWS region to puppet-code

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -56,6 +56,9 @@ locals {
       description = "Puppet Configuration. Modules, Manifests and Hiera."
       team_id     = github_team.dev.id
       type        = "other"
+      secrets = {
+        AWS_DEFAULT_REGION = local.aws_default_region
+      }
     }
 
     "terraform-aws-service-network" : {


### PR DESCRIPTION
puppet-code need a region because it uploads packages to S3, reads GPG
keys from secretsmanager.
