### PR TITLE
Update README, secrets part

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 5
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      AWS_DEFAULT_REGION: "us-west-1"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -35,7 +36,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::289256138624:role/ih-tf-github-control
           role-session-name: ih-tf-terraform-control-github-control
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       # Install the latest version of Terraform CLI
       - name: Setup Terraform

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 5
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      AWS_DEFAULT_REGION: "us-west-1"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -32,7 +33,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::289256138624:role/ih-tf-github-control
           role-session-name: ih-tf-terraform-control-github-control
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       # Install the latest version of Terraform CLI
       - name: Setup Terraform

--- a/README.rst
+++ b/README.rst
@@ -57,18 +57,6 @@ Secrets
 ~~~~~~~
 Defined in https://github.com/infrahouse8/github-control/settings/secrets/actions.
 
-``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, ``AWS_DEFAULT_REGION``
-    AWS credentials of a user that has privileges to work with a Terraform state in S3.
-    Minimal privileges required [#]_:
-
-    * ``ListBucket``
-    * ``GetObject``
-    * ``PutObject``
-    * ``DeleteObject``
-
 ``GH_TOKEN``
     Personal token of a user `infrahouse8 <https://github.com/infrahouse8>`_.
     Created in https://github.com/settings/tokens.
-
-.. [#] The repository doesn't use Terraform state locking at the moment.
-    If it did, additional privileges would be needed to work with a DynamoDB table.

--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -4,7 +4,6 @@ locals {
       description       = "InfraHouse GitHub configuration"
       tf_admin_username = "tf_github"
       secrets = {
-        AWS_ROLE = "arn:aws:iam::${local.aws_account_id}:role/github-admin"
       }
     }
   }
@@ -20,8 +19,7 @@ module "ih_8_repos" {
   template_repo    = contains(keys(each.value), "template_repo") ? each.value["template_repo"] : null
   secrets = merge(contains(keys(each.value), "secrets") ? each.value["secrets"] : {},
     {
-      AWS_DEFAULT_REGION = "us-west-1"
-      GH_TOKEN           = data.external.env.result["GH_TOKEN"]
+      GH_TOKEN = data.external.env.result["GH_TOKEN"]
     }
   )
   collaborators = [


### PR DESCRIPTION
github-control doesn't use the AWS access key to work with AWS.
Innstead, it uses an IAM role. Update the readme to remove references to
the access key.
