### PR TITLE
Add outputs infrahouse8-github-control

### DIFF
--- a/modules/ci-cd/outputs.tf
+++ b/modules/ci-cd/outputs.tf
@@ -6,6 +6,10 @@ output "admin-role" {
   value = module.gha-admin.admin_role_arn
 }
 
+output "state-manager-role" {
+  value = module.gha-admin.state_manager_role_arn
+}
+
 output "bucket_name" {
   value = module.state-bucket.bucket_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,18 @@
+output "github-control-lock-table" {
+  description = "A DynamoDB table name for state lock in github-control."
+  value       = module.infrahouse8-github-control.lock_table_name
+}
+
+output "github-control-state-bucket" {
+  description = "An S3 bucket for github-control state."
+  value       = module.infrahouse8-github-control.bucket_name
+}
+
+output "github-control-roles" {
+  description = "Terraform CI/CD roles used in github-control."
+  value = {
+    "github" : module.infrahouse8-github-control.github-role
+    "state-manager" : module.infrahouse8-github-control.state-manager-role
+    "admin" : module.infrahouse8-github-control.admin-role
+  }
+}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 boto3 ~= 1.26
-infrahouse-toolkit ~= 1.2
+infrahouse-toolkit ~= 2.4
 pyhcl ~= 0.4
 yamllint ~= 1.29


### PR DESCRIPTION
The output variables are needed for github-control CI/CD configuration.
