### PR TITLE
Use new roles for github-control

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_DEFAULT_REGION: "us-west-1"
+      GHA_ROLE: "arn:aws:iam::303467602807:role/ih-tf-github-control-github"
+      STATE_MANAGER_ROLE: "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -34,7 +36,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::289256138624:role/ih-tf-github-control
+          role-to-assume: ${{ env.GHA_ROLE }}
           role-session-name: ih-tf-terraform-control-github-control
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
@@ -49,7 +51,8 @@ jobs:
       # Download a plan from the approved pull request
       - name: Download plan
         run: |
-          ih-plan download \
+          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+            download \
             plans/${{ github.event.pull_request.number }}.plan \
             tf.plan
 
@@ -69,5 +72,6 @@ jobs:
 
       - name: Remove plan
         run: |
-          ih-plan remove \
+          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+            remove \
             plans/${{ github.event.pull_request.number }}.plan

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -17,6 +17,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_DEFAULT_REGION: "us-west-1"
+      GHA_ROLE: "arn:aws:iam::303467602807:role/ih-tf-github-control-github"
+      STATE_MANAGER_ROLE: "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -31,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::289256138624:role/ih-tf-github-control
+          role-to-assume: ${{ env.GHA_ROLE }}
           role-session-name: ih-tf-terraform-control-github-control
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
@@ -65,6 +67,5 @@ jobs:
       # Upload Terraform Plan
       - name: Upload Terraform Plan
         run: |
-          ih-plan upload \
-            --key-name=plans/${{ github.event.pull_request.number }}.plan \
-            tf.plan
+          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+            upload --key-name=plans/${{ github.event.pull_request.number }}.plan tf.plan

--- a/provider.aws.tf
+++ b/provider.aws.tf
@@ -2,7 +2,7 @@ provider "aws" {
   alias  = "aws-303467602807-uw1"
   region = "us-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::303467602807:role/ih-tf-cicd-control"
+    role_arn = "arn:aws:iam::303467602807:role/ih-tf-github-control-admin"
   }
 }
 
@@ -10,7 +10,7 @@ provider "aws" {
   alias  = "aws-303467602807-uw2"
   region = "us-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::303467602807:role/ih-tf-cicd-control"
+    role_arn = "arn:aws:iam::303467602807:role/ih-tf-github-control-admin"
   }
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket   = "infrahouse-github-state"
-    key      = "github.state"
+    bucket   = "infrahouse-github-control-state"
+    key      = "terraform.tfstate"
     region   = "us-west-1"
-    role_arn = "arn:aws:iam::289256138624:role/ih-tf-terraform-control"
+    role_arn = "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
   }
 
   required_providers {


### PR DESCRIPTION
The ci-cd module create a bucket and roles for Terraform CI/CD in
github-control. Migrate the bucket and use the roles.
