### PR TITLE
Save github-control roles in GHA variables

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -47,3 +47,54 @@ module "ih8_tf_template" {
     github = github.infrahouse8
   }
 }
+
+
+module "infrahouse8-github-control" {
+  source  = "infrahouse/ci-cd/aws"
+  version = "~> 1.0"
+  providers = {
+    aws          = aws.aws-303467602807-uw1
+    aws.cicd     = aws.aws-303467602807-uw1
+    aws.tfstates = aws.aws-289256138624-uw1
+  }
+  gh_org       = "infrahouse8"
+  gh_repo      = "github-control"
+  state_bucket = "infrahouse-github-control-state"
+  allowed_arns = [
+    "arn:aws:iam::289256138624:role/ih-tf-terraform-control"
+  ]
+  trusted_arns = [
+    local.me_arn
+  ]
+}
+
+
+resource "github_actions_variable" "role-admin" {
+  repository    = module.ih_8_repos["github-control"].repo_name
+  value         = module.infrahouse8-github-control.admin-role
+  variable_name = "role-admin"
+}
+
+resource "github_actions_variable" "role-github" {
+  repository    = module.ih_8_repos["github-control"].repo_name
+  value         = module.infrahouse8-github-control.github-role
+  variable_name = "role-github"
+}
+
+resource "github_actions_variable" "role-state-manager" {
+  repository    = module.ih_8_repos["github-control"].repo_name
+  value         = module.infrahouse8-github-control.state-manager-role
+  variable_name = "role-state-manager"
+}
+
+resource "github_actions_variable" "state-bucket" {
+  repository    = module.ih_8_repos["github-control"].repo_name
+  value         = module.infrahouse8-github-control.bucket_name
+  variable_name = "state-bucket"
+}
+
+resource "github_actions_variable" "dynamodb-lock-table-name" {
+  repository    = module.ih_8_repos["github-control"].repo_name
+  value         = module.infrahouse8-github-control.lock_table_name
+  variable_name = "dynamodb-lock-table-name"
+}

--- a/main.tf
+++ b/main.tf
@@ -25,23 +25,3 @@ resource "github_organization_settings" "infrahouse" {
   secret_scanning_enabled_for_new_repositories                 = false
   secret_scanning_push_protection_enabled_for_new_repositories = false
 }
-
-
-module "infrahouse8-github-control" {
-  source  = "infrahouse/ci-cd/aws"
-  version = "~> 1.0"
-  providers = {
-    aws          = aws.aws-303467602807-uw1
-    aws.cicd     = aws.aws-303467602807-uw1
-    aws.tfstates = aws.aws-289256138624-uw1
-  }
-  gh_org       = "infrahouse8"
-  gh_repo      = "github-control"
-  state_bucket = "infrahouse-github-control-state"
-  allowed_arns = [
-    "arn:aws:iam::289256138624:role/ih-tf-terraform-control"
-  ]
-  trusted_arns = [
-    local.me_arn
-  ]
-}

--- a/modules/local-repo/outputs.tf
+++ b/modules/local-repo/outputs.tf
@@ -1,0 +1,4 @@
+output "repo_name" {
+  description = "Name of the created repository"
+  value       = github_repository.repo.name
+}


### PR DESCRIPTION
Module `infrahouse/ci-cd/aws` creates a bucket, dynamodb table for state
locks, and roles for CI/CD. Save it all in variables.
