### PR TITLE
Use AWS IAM roles in GHA from variables.

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -20,8 +20,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_DEFAULT_REGION: "us-west-1"
-      GHA_ROLE: "arn:aws:iam::303467602807:role/ih-tf-github-control-github"
-      STATE_MANAGER_ROLE: "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -36,7 +34,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ env.GHA_ROLE }}
+          role-to-assume: ${{ vars.ROLE_GITHUB }}
           role-session-name: ih-tf-terraform-control-github-control
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
@@ -51,7 +49,7 @@ jobs:
       # Download a plan from the approved pull request
       - name: Download plan
         run: |
-          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+          ih-plan --aws-assume-role-arn ${{ vars.ROLE_STATE_MANAGER }} \
             download \
             plans/${{ github.event.pull_request.number }}.plan \
             tf.plan
@@ -72,6 +70,6 @@ jobs:
 
       - name: Remove plan
         run: |
-          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+          ih-plan --aws-assume-role-arn ${{ vars.ROLE_STATE_MANAGER }} \
             remove \
             plans/${{ github.event.pull_request.number }}.plan

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -17,8 +17,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       AWS_DEFAULT_REGION: "us-west-1"
-      GHA_ROLE: "arn:aws:iam::303467602807:role/ih-tf-github-control-github"
-      STATE_MANAGER_ROLE: "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -33,7 +31,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ env.GHA_ROLE }}
+          role-to-assume: ${{ vars.ROLE_GITHUB }}
           role-session-name: ih-tf-terraform-control-github-control
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
@@ -58,5 +56,5 @@ jobs:
       # Upload Terraform Plan
       - name: Upload Terraform Plan
         run: |
-          ih-plan --aws-assume-role-arn ${{ env.STATE_MANAGER_ROLE }} \
+          ih-plan --aws-assume-role-arn ${{ vars.ROLE_STATE_MANAGER }} \
             upload --key-name=plans/${{ github.event.pull_request.number }}.plan tf.plan

--- a/provider.aws.tf
+++ b/provider.aws.tf
@@ -2,7 +2,7 @@ provider "aws" {
   alias  = "aws-303467602807-uw1"
   region = "us-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::303467602807:role/ih-tf-github-control-admin"
+    role_arn = var.role_admin
   }
   default_tags {
     tags = var.default_tags
@@ -14,7 +14,7 @@ provider "aws" {
   alias  = "aws-303467602807-uw2"
   region = "us-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::303467602807:role/ih-tf-github-control-admin"
+    role_arn = var.role_admin
   }
   default_tags {
     tags = var.default_tags

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,11 @@
 terraform {
   backend "s3" {
-    bucket   = "infrahouse-github-control-state"
-    key      = "terraform.tfstate"
-    region   = "us-west-1"
-    role_arn = "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
+    bucket         = "infrahouse-github-control-state"
+    key            = "terraform.tfstate"
+    region         = "us-west-1"
+    role_arn       = "arn:aws:iam::289256138624:role/ih-tf-github-control-state-manager"
+    dynamodb_table = "infrahouse-github-control-state-polished-lioness"
+    encrypt        = true
   }
 
   required_providers {

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,3 +1,5 @@
 default_tags = {
   "created_by" : "infrahouse8/github-control" # GitHub repository that created a resource
 }
+
+role_admin = "arn:aws:iam::303467602807:role/ih-tf-github-control-admin"

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,7 @@ variable "default_tags" {
   description = "A map with tags that will be applied to all resources created by the AWS provider"
   type        = map(string)
 }
+
+variable "role_admin" {
+  description = "Role in the principal AWS account"
+}


### PR DESCRIPTION
Now that we created IAM roles and published their names to GitHub Action
variables, use the variable names in CI and CD.
