### PR TITLE
Disallow github update to 5.43

### DIFF
--- a/modules/plain-repo/repos.tf
+++ b/modules/plain-repo/repos.tf
@@ -1,9 +1,8 @@
 resource "github_repository" "repo" {
-  name                        = var.repo_name
-  description                 = var.repo_description
-  has_issues                  = true
-  visibility                  = "public"
-  web_commit_signoff_required = true
+  name        = var.repo_name
+  description = var.repo_description
+  has_issues  = true
+  visibility  = "public"
 }
 
 resource "github_team_repository" "dev" {

--- a/modules/repo-template/repos.tf
+++ b/modules/repo-template/repos.tf
@@ -1,10 +1,9 @@
 resource "github_repository" "repo" {
-  name                        = var.repo_name
-  description                 = var.repo_description
-  has_issues                  = true
-  visibility                  = "public"
-  is_template                 = true
-  web_commit_signoff_required = true
+  name        = var.repo_name
+  description = var.repo_description
+  has_issues  = true
+  visibility  = "public"
+  is_template = true
 }
 
 resource "github_team_repository" "dev" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 5.27"
+      version = "~> 5.27, < 5.43"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
There is a bug
https://github.com/integrations/terraform-provider-github/issues/2077 .
The github provider version 5.43 made some changes around
web_commit_signoff_required option. Disable upgrade until the bug is
fixed.
