### PR TITLE
Set role to infrahouse-github-backup

### DIFF
--- a/modules/infrahouse-github-backup/locals.tf
+++ b/modules/infrahouse-github-backup/locals.tf
@@ -1,6 +1,5 @@
 locals {
   infrahouse_roles = [
-    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
-    "arn:aws:iam::493370826424:role/jumphost-Zv01ElhajbB620240223005112032800000005",
+    "arn:aws:iam::493370826424:role/infrahouse-github-backup",
   ]
 }


### PR DESCRIPTION
The role `arn:aws:iam::493370826424:role/infrahouse-github-backup` is
expected to be final. It's a role the infrahouse-github-backup EC2
instance gets via a profile.
