### PR TITLE
Allow ih-tf-aws-control-303467602807-admin to read infrahouse-github-terraform-app-key

### DIFF
--- a/infrahouse-github-terraform.tf
+++ b/infrahouse-github-terraform.tf
@@ -14,4 +14,7 @@ module "infrahouse-github-terraform-pem" {
   writers = [
     tolist(data.aws_iam_roles.sso-admin.arns)[0]
   ]
+  readers = [
+    data.aws_iam_role.ih-tf-aws-control-303467602807-admin.arn,
+  ]
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -33,7 +33,6 @@ module "actions-runner-pem" {
   readers = [
     data.aws_iam_role.actions-runner-tester.arn,
     tolist(data.aws_iam_roles.sso-admin.arns)[0],
-    data.aws_iam_role.ih-tf-aws-control-303467602807-admin.arn,
     "arn:aws:iam::303467602807:role/infrahouse-registration*"
   ]
 }


### PR DESCRIPTION
previously, the permission was granted to a wrong secret.
