### PR TITLE
Update osv-scanner-reusable.yml to @v2

### DIFF
--- a/modules/plain-repo/files/vuln-scanner-pr-public.yml
+++ b/modules/plain-repo/files/vuln-scanner-pr-public.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   vulnerability-check:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.0"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2"
     with:
       scan-args: --config osv-scanner.toml
       upload-sarif: false


### PR DESCRIPTION
I don't need exact version for OSV scanner.
When it *is* exact, renovate triggers a pull request to every little
release.
