### PR TITLE
Fix OSV Scanner version and prevent workflow updates from triggering reviews

### DIFF
--- a/modules/plain-repo/files/terraform-review.yml
+++ b/modules/plain-repo/files/terraform-review.yml
@@ -7,6 +7,8 @@ name: Terraform Module Review
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
 
 concurrency:
   group: terraform-review-${{ github.event.pull_request.number }}

--- a/modules/plain-repo/files/vuln-scanner-pr-public.yml
+++ b/modules/plain-repo/files/vuln-scanner-pr-public.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   vulnerability-check:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.0"
     with:
       scan-args: --config osv-scanner.toml
       upload-sarif: false


### PR DESCRIPTION
- Update osv-scanner-action from invalid @v2 tag to @v2.3.0
  The @v2 tag doesn't exist; google/osv-scanner-action uses semantic
  versioning tags like v2.3.0

- Add paths-ignore to terraform-review workflow
  Prevent workflow file updates from triggering unnecessary Terraform
  module reviews by ignoring changes to .github/workflows/**

This ensures workflow updates (like vulnerability scanner changes)
don't waste CI resources running Terraform reviews.
