### PR TITLE
Fix hardcoded repository name in cliff.toml

### DIFF
--- a/modules/plain-repo/files/cliff.toml.tpl
+++ b/modules/plain-repo/files/cliff.toml.tpl
@@ -43,7 +43,7 @@ filter_unconventional = true
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/infrahouse/terraform-aws-elasticsearch/issues/${2}))"}, # link to issue
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#$${2}](https://github.com/infrahouse/${repo_name}/issues/$${2}))"}, # link to issue
 ]
 # regex for parsing and grouping commits
 commit_parsers = [

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -78,9 +78,11 @@ resource "github_repository_file" "cliff_config" {
   depends_on = [
     github_repository_ruleset.main
   ]
-  repository          = github_repository.repo.name
-  file                = "./cliff.toml"
-  content             = file("${path.module}/files/cliff.toml")
+  repository = github_repository.repo.name
+  file       = "./cliff.toml"
+  content = templatefile("${path.module}/files/cliff.toml.tpl", {
+    repo_name = github_repository.repo.name
+  })
   commit_message      = "Add cliff.toml configuration"
   overwrite_on_create = true
 }


### PR DESCRIPTION
Replace static cliff.toml with templatefile to dynamically inject
repository name in commit preprocessor issue links. Previously,
all repos incorrectly linked to terraform-aws-elasticsearch issues.
