### PR TITLE
Ignore .github/workflows/vuln-scanner-pr.yml in renovate

### DIFF
--- a/modules/plain-repo/files/renovate.json
+++ b/modules/plain-repo/files/renovate.json
@@ -12,6 +12,7 @@
         ".github/workflows/terraform-CD.yml",
         ".github/workflows/vuln-scanner-pr-public.yml",
         ".github/workflows/vuln-scanner-pr-private.yml",
+        ".github/workflows/vuln-scanner-pr.yml",
         ".github/workflows/terraform-review.yml"
       ],
       "enabled": false


### PR DESCRIPTION
The `.github/workflows/vuln-scanner-pr.yml` file is managed in
github-control, thus has to be updated there.
