### PR TITLE
Enable GitHub Pages for all terraform_module repositories

### DIFF
--- a/modules/plain-repo/files/docs.yml
+++ b/modules/plain-repo/files/docs.yml
@@ -1,0 +1,69 @@
+---
+name: 'Deploy Documentation'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: 'Build Documentation'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git info
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-mkdocs-${{ hashFiles('**/requirements-docs.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-mkdocs-
+
+      - name: Install dependencies
+        run: |
+          make bootstrap
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: 'Deploy to GitHub Pages'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/modules/plain-repo/files/mkdocs.yml.tpl
+++ b/modules/plain-repo/files/mkdocs.yml.tpl
@@ -1,0 +1,74 @@
+site_name: InfraHouse ${repo_name}
+site_url: https://infrahouse.github.io/${repo_name}/
+site_description: Terraform module documentation
+site_author: InfraHouse
+
+repo_url: https://github.com/infrahouse/${repo_name}
+repo_name: infrahouse/${repo_name}
+
+theme:
+  name: material
+  icon:
+    logo: material/server
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.highlight
+    - search.share
+
+nav:
+  - Home: index.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - admonition
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/infrahouse
+    - icon: fontawesome/solid/globe
+      link: https://infrahouse.com
+
+copyright: Copyright &copy; 2024-2026 InfraHouse

--- a/modules/plain-repo/files/renovate.json
+++ b/modules/plain-repo/files/renovate.json
@@ -13,7 +13,8 @@
         ".github/workflows/vuln-scanner-pr-public.yml",
         ".github/workflows/vuln-scanner-pr-private.yml",
         ".github/workflows/vuln-scanner-pr.yml",
-        ".github/workflows/terraform-review.yml"
+        ".github/workflows/terraform-review.yml",
+        ".github/workflows/docs.yml"
       ],
       "enabled": false
     }

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -120,3 +120,41 @@ resource "github_repository_file" "commit_msg_hook" {
   commit_message      = "Add commit-msg hook"
   overwrite_on_create = true
 }
+
+resource "github_repository_file" "docs_workflow" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "./.github/workflows/docs.yml"
+  content             = file("${path.module}/files/docs.yml")
+  commit_message      = "Add docs.yml workflow for GitHub Pages"
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "docs_index" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "./docs/index.md"
+  content             = "# ${github_repository.repo.name}\n\n${github_repository.repo.description}\n"
+  commit_message      = "Add docs/index.md"
+  overwrite_on_create = false
+}
+
+resource "github_repository_file" "mkdocs_config" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository = github_repository.repo.name
+  file       = "./mkdocs.yml"
+  content = templatefile("${path.module}/files/mkdocs.yml.tpl", {
+    repo_name = github_repository.repo.name
+  })
+  commit_message      = "Add mkdocs.yml configuration"
+  overwrite_on_create = false
+}

--- a/repos.tf
+++ b/repos.tf
@@ -316,7 +316,10 @@ module "repos" {
   allow_auto_merge  = try(each.value["auto_merge"], null)
   repo_type         = try(each.value["type"], null)
   anthropic_api_key = module.anthropic_api_key.secret_value
-  enable_pages      = try(each.value["enable_pages"], false)
+  enable_pages = try(
+    each.value["enable_pages"],
+    each.value["type"] == "terraform_module"
+  )
   secrets = merge(
     contains(keys(each.value), "secrets") ? each.value["secrets"] : {},
     merge(


### PR DESCRIPTION
Automatically configure GitHub Pages documentation for all Terraform modules:

- Auto-enable Pages for repos with type="terraform_module"
- Deploy docs.yml workflow for MkDocs builds
- Create placeholder docs/index.md and mkdocs.yml if missing
- Configure Renovate to ignore docs.yml workflow
