### PR TITLE
Add lifecycle blocks to prevent overwriting docs content

### DIFF
--- a/modules/plain-repo/files/docs.yml
+++ b/modules/plain-repo/files/docs.yml
@@ -1,7 +1,7 @@
 ---
 name: 'Deploy Documentation'
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -143,6 +143,10 @@ resource "github_repository_file" "docs_index" {
   content             = "# ${github_repository.repo.name}\n\n${github_repository.repo.description}\n"
   commit_message      = "Add docs/index.md"
   overwrite_on_create = false
+
+  lifecycle {
+    ignore_changes = [content]
+  }
 }
 
 resource "github_repository_file" "mkdocs_config" {
@@ -157,4 +161,8 @@ resource "github_repository_file" "mkdocs_config" {
   })
   commit_message      = "Add mkdocs.yml configuration"
   overwrite_on_create = false
+
+  lifecycle {
+    ignore_changes = [content]
+  }
 }


### PR DESCRIPTION
Prevent Terraform from updating docs/index.md and mkdocs.yml content
after initial creation, allowing manual customization per repository.
