### PR TITLE
Improve Renovate config and deploy to all repos

### DIFF
--- a/modules/plain-repo/files/renovate.json
+++ b/modules/plain-repo/files/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "prConcurrentLimit": 1,
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],

--- a/modules/plain-repo/repo-files.tf
+++ b/modules/plain-repo/repo-files.tf
@@ -1,8 +1,0 @@
-resource "github_repository_file" "renovate-json" {
-  count               = var.repo_type == "terraform_module" ? 1 : 0
-  repository          = github_repository.repo.name
-  file                = "renovate.json"
-  content             = file("${path.module}/files/renovate.json")
-  commit_message      = "Configure renovate"
-  overwrite_on_create = true
-}

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -1,7 +1,18 @@
 locals {
   vuln_scanner_workflow = var.public_repo ? "vuln-scanner-pr-public.yml" : "vuln-scanner-pr-private.yml"
-
 }
+
+resource "github_repository_file" "renovate_json" {
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "renovate.json"
+  content             = file("${path.module}/files/renovate.json")
+  commit_message      = "Configure renovate"
+  overwrite_on_create = true
+}
+
 resource "github_repository_file" "vuln_scanner_workflow" {
   depends_on = [
     github_repository_ruleset.main


### PR DESCRIPTION
## Summary
- Add `rebaseWhen: "conflicted"` to prevent Renovate from rebasing PRs when main moves forward (only rebase on actual merge conflicts)
- Deploy renovate.json to all repos, not just terraform_module type
- Consolidate renovate resource into repos-files.tf and remove redundant repo-files.tf

## Test plan
- [ ] Verify Terraform plan shows renovate.json being added to non-terraform_module repos
- [ ] Confirm existing terraform_module repos show minimal changes (state rename)
- [ ] After merge, verify Renovate PRs no longer auto-rebase on unrelated main commits


