### PR TITLE
feat: Add LICENSE, CONTRIBUTING.md, and review-local command to terraform_module repos

### DIFF
--- a/modules/plain-repo/files/CODING_STANDARD.md
+++ b/modules/plain-repo/files/CODING_STANDARD.md
@@ -293,13 +293,13 @@ This document defines coding standards for InfraHouse projects.
   - Must include terraform-docs markers: `<!-- BEGIN_TF_DOCS -->` and `<!-- END_TF_DOCS -->`
   - Pre-commit hook uses terraform-docs to auto-generate documentation
   - **Required badges** (in this order):
-    - Terraform Registry: `[![Registry](https://img.shields.io/badge/terraform-registry-623CE4?logo=terraform)](registry-url)`
-    - Latest Release: `[![GitHub release](https://img.shields.io/github/v/release/infrahouse/repo-name)](release-url)`
-    - License: `[![License](https://img.shields.io/github/license/infrahouse/repo-name)](LICENSE)`
-    - Documentation: `[![Docs](https://img.shields.io/badge/docs-github.io-blue)](https://infrahouse.github.io/repo-name/)`
-    - Security: `[![Security](https://github.com/infrahouse/repo-name/actions/workflows/vuln-scanner-pr.yml/badge.svg)](workflow-url)`
-    - AWS Service Badge(s): Link to relevant AWS service(s) the module uses
     - Contact: `[![Need Help?](https://img.shields.io/badge/Need%20Help%3F-Contact%20Us-0066CC)](https://infrahouse.com/contact)`
+    - Documentation: `[![Docs](https://img.shields.io/badge/docs-github.io-blue)](https://infrahouse.github.io/repo-name/)`
+    - Terraform Registry: `[![Registry](https://img.shields.io/badge/Terraform-Registry-purple?logo=terraform)](https://registry.terraform.io/modules/infrahouse/module-name/aws/latest)`
+    - Latest Release: `[![Release](https://img.shields.io/github/release/infrahouse/repo-name.svg)](https://github.com/infrahouse/repo-name/releases/latest)`
+    - AWS Service Badge(s): `[![AWS EC2](https://img.shields.io/badge/AWS-EC2-orange?logo=amazonec2)](https://aws.amazon.com/ec2/)` (link to relevant AWS service(s))
+    - Security: `[![Security](https://img.shields.io/github/actions/workflow/status/infrahouse/repo-name/vuln-scanner-pr.yml?label=Security)](https://github.com/infrahouse/repo-name/actions/workflows/vuln-scanner-pr.yml)`
+    - License: `[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)`
   - **Required sections:**
     1. Brief description (what it does, why it exists)
     2. Features (bullet list)

--- a/modules/plain-repo/files/CONTRIBUTING.md
+++ b/modules/plain-repo/files/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to this Project
+
+Thank you for your interest in contributing! This document provides guidelines for contributing to this Terraform module.
+
+## How to Contribute
+
+### Reporting Issues
+
+- Check existing issues before creating a new one
+- Use a clear, descriptive title
+- Include Terraform and provider versions
+- Provide minimal reproduction steps
+- Include relevant logs or error messages
+
+### Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes following our coding standards
+4. Write or update tests as needed
+5. Run `make test-clean` to verify all tests pass
+6. Submit a pull request
+
+### Pull Request Guidelines
+
+- Reference any related issues
+- Provide a clear description of changes
+- Ensure CI checks pass
+- Keep changes focused and atomic
+- Update documentation if needed
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/REPO_NAME.git
+cd REPO_NAME
+
+# Install dependencies
+make bootstrap
+
+# Run tests (keeps infrastructure for debugging)
+make test-keep
+
+# Run tests with cleanup (before PR)
+make test-clean
+```
+
+## Coding Standards
+
+Please follow the coding standards defined in `.claude/CODING_STANDARD.md`:
+
+- Use `terraform fmt` for formatting
+- Follow naming conventions (snake_case)
+- Add descriptions to all variables and outputs
+- Include validation blocks where appropriate
+- Use conventional commits for commit messages
+
+## Commit Message Format
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: Add support for custom IAM policies
+fix: Correct security group ingress rules
+docs: Update README with new examples
+refactor: Simplify variable validation logic
+```
+
+## Testing
+
+- Tests use pytest with pytest-infrahouse fixtures
+- Tests create real AWS infrastructure
+- Always run `make test-clean` before submitting PR
+- Ensure tests pass for all supported AWS provider versions
+
+## Questions?
+
+- Open a GitHub issue for questions about contributing
+- See [SECURITY.md](SECURITY.md) for reporting security vulnerabilities
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project.

--- a/modules/plain-repo/files/LICENSE
+++ b/modules/plain-repo/files/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 InfraHouse Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/modules/plain-repo/files/review-local.md
+++ b/modules/plain-repo/files/review-local.md
@@ -1,0 +1,96 @@
+---
+description: Run Terraform module review locally (similar to GitHub PR review)
+---
+
+You are running a local Terraform module review, similar to the automated GitHub PR review workflow.
+
+## Your Task
+
+1. **Create review directory:**
+   ```bash
+   mkdir -p .claude/reviews
+   ```
+
+2. **Check for previous review:**
+   - Look for `.claude/reviews/terraform-module-review.md`
+   - If it exists, this is a follow-up review (read the existing file as the "previous" review)
+   - If it doesn't exist, this is the first review
+
+3. **Get changes to review:**
+   - First, check what changes exist:
+     ```bash
+     # Check for uncommitted changes
+     git status --short
+
+     # Check for commits ahead of main/master
+     git log --oneline origin/main..HEAD 2>/dev/null || git log --oneline origin/master..HEAD 2>/dev/null || echo "No remote branch found"
+     ```
+
+   - Based on what's found, create a diff file in .claude/reviews/:
+     - **If there are uncommitted changes:** `git diff HEAD > .claude/reviews/pr-changes.diff`
+     - **If there are committed changes ahead of main:** `git diff origin/main...HEAD > .claude/reviews/pr-changes.diff` (or origin/master)
+     - **If no changes:** Tell the user there's nothing to review
+
+4. **Show the user what will be reviewed:**
+   ```bash
+   echo "Changes to review:"
+   cat .claude/reviews/pr-changes.diff | head -50
+   echo ""
+   echo "Total lines in diff: $(wc -l < .claude/reviews/pr-changes.diff)"
+   ```
+
+5. **Launch the terraform-module-reviewer agent:**
+
+   **For FIRST review (no previous review found):**
+   ```
+   Launch the terraform-module-reviewer agent.
+
+   Review all changes in .claude/reviews/pr-changes.diff file.
+
+   Focus your review on the changes made while considering the overall module context.
+   Analyze what was added, modified, or removed, and assess the impact on:
+   - Security
+   - Functionality
+   - Best practices compliance
+   - Code standards
+
+   IMPORTANT: Save your complete review to .claude/reviews/terraform-module-review.md
+   as specified in your agent instructions.
+   ```
+
+   **For FOLLOW-UP review (previous review exists):**
+   ```
+   Launch the terraform-module-reviewer agent.
+
+   This is a follow-up review.
+
+   Read the previous review from .claude/reviews/terraform-module-review.md
+   and the current changes in .claude/reviews/pr-changes.diff.
+
+   Compare the previous findings with the current state:
+   - Mark issues as '✅ FIXED:' if they have been resolved
+   - Mark issues as '⚠️ STILL PRESENT:' if unaddressed
+   - Mark new issues as '🆕 NEW:' if they appear for the first time
+   - Provide a summary at the top showing progress
+     (e.g., '3 issues fixed, 1 still present, 2 new issues found')
+
+   Focus on showing what has improved and what still needs attention.
+
+   IMPORTANT: Overwrite .claude/reviews/terraform-module-review.md with your
+   new review (replacing the previous one) as specified in your agent instructions.
+   ```
+
+6. **After the agent completes:**
+   - Verify the review was created/updated: `ls -lh .claude/reviews/terraform-module-review.md`
+   - Show the user where to find it
+   - Let them know they can:
+     - Read the review now
+     - Make changes and run /review again to see what improved
+
+## Important Notes
+
+- This review runs **locally** - it won't post to GitHub
+- The review helps you catch issues **before** creating a PR
+- You can iterate: make changes → run /review again → see what improved
+- Each /review run overwrites the previous review (showing your progress)
+- When you're satisfied, create your PR and the GitHub workflow will do the official review

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -36,6 +36,18 @@ resource "github_repository_file" "terraform_module_reviewer" {
   overwrite_on_create = true
 }
 
+resource "github_repository_file" "review_local_command" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "./.claude/commands/review-local.md"
+  content             = file("${path.module}/files/review-local.md")
+  commit_message      = "Add review-local Claude command"
+  overwrite_on_create = true
+}
+
 resource "github_repository_file" "coding_standard" {
   depends_on = [
     github_repository_ruleset.main
@@ -165,6 +177,30 @@ resource "github_repository_file" "security_md" {
   file                = "SECURITY.md"
   content             = file("${path.module}/files/SECURITY.md")
   commit_message      = "Add SECURITY.md"
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "contributing_md" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "CONTRIBUTING.md"
+  content             = file("${path.module}/files/CONTRIBUTING.md")
+  commit_message      = "Add CONTRIBUTING.md"
+  overwrite_on_create = true
+}
+
+resource "github_repository_file" "license" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "LICENSE"
+  content             = file("${path.module}/files/LICENSE")
+  commit_message      = "Add LICENSE"
   overwrite_on_create = true
 }
 


### PR DESCRIPTION
- Add Apache 2.0 LICENSE template for all terraform_module repos
- Add CONTRIBUTING.md with contribution guidelines
- Add review-local.md Claude command for local pre-PR reviews
- Update README badge layout in CODING_STANDARD.md:
  - New order: Contact, Docs, Registry, Release, AWS, Security, License
  - Updated badge formats with improved styling
