### PR TITLE
feat: Improve Claude instructions and deploy TERRAFORM_MODULE_REQUIREMENTS.md

### DIFF
--- a/modules/plain-repo/files/TERRAFORM_MODULE_REQUIREMENTS.md
+++ b/modules/plain-repo/files/TERRAFORM_MODULE_REQUIREMENTS.md
@@ -62,7 +62,6 @@ Provide comprehensive, professional documentation and tooling for all InfraHouse
 - `CODING_STANDARD.md` (or link to central one)
 - `.terraform-docs.yml`
 - `mkdocs.yml`
-- `.pre-commit-config.yaml` (if using pre-commit framework)
 - `.github/workflows/release.yml` (auto-create GitHub Releases from tags)
 - `examples/` directory with working examples
 

--- a/modules/plain-repo/files/instructions.md
+++ b/modules/plain-repo/files/instructions.md
@@ -1,14 +1,21 @@
 # Project Instructions for Claude Code
 
-## Terraform Coding Standards
+## First Steps (Do This Immediately)
 
-**ALWAYS read and follow `.claude/CODING_STANDARD.md` before writing or modifying any Terraform code.**
+### Session set up
+- [ ] *ALWAYS* Read `.claude/CODING_STANDARD.md`
+- [ ] Confirm to the user that you have read it.
 
-This file contains critical requirements including:
-- Proper use of ternary operators vs logical OR in validation blocks with nullable variables
-- Tagging conventions
-- Provider requirements
-- Module pinning
-- IAM policy patterns
 
-Pay special attention to validation blocks - they require ternary operators to avoid null comparison errors.
+### Generating CLAUDE.md
+
+When generating or updating CLAUDE.md, include this text verbatim as the first section after the intro paragraph:
+
+```markdown
+## First Steps
+
+**Your first tool call in this repository MUST be reading .claude/CODING_STANDARD.md.
+Do not read any other files, search, or take any actions until you have read it.**
+This contains InfraHouse's comprehensive coding standards for Terraform, Python, and general formatting rules.
+```
+End the CLAUDE.md file with a newline.

--- a/modules/plain-repo/files/terraform-review.yml
+++ b/modules/plain-repo/files/terraform-review.yml
@@ -94,6 +94,7 @@ jobs:
         if: steps.check_previous.outputs.has_previous == 'false'
         run: |
           npx @anthropic-ai/claude-code --print --output-format json \
+            --model opus \
             --dangerously-skip-permissions \
             "Launch the terraform-module-reviewer agent. \
           Review all changes in pr-changes.diff file. \
@@ -113,6 +114,7 @@ jobs:
         if: steps.check_previous.outputs.has_previous == 'true'
         run: |
           npx @anthropic-ai/claude-code --print --output-format json \
+            --model opus \
             --dangerously-skip-permissions \
             "Launch the terraform-module-reviewer agent. \
           This is a follow-up review. \

--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -237,3 +237,15 @@ resource "github_repository_file" "mkdocs_config" {
     ignore_changes = [content]
   }
 }
+
+resource "github_repository_file" "terraform_module_requirements" {
+  count = var.repo_type == "terraform_module" ? 1 : 0
+  depends_on = [
+    github_repository_ruleset.main
+  ]
+  repository          = github_repository.repo.name
+  file                = "./.claude/TERRAFORM_MODULE_REQUIREMENTS.md"
+  content             = file("${path.module}/files/TERRAFORM_MODULE_REQUIREMENTS.md")
+  commit_message      = "Add TERRAFORM_MODULE_REQUIREMENTS.md"
+  overwrite_on_create = true
+}


### PR DESCRIPTION
- Restructure instructions.md with "First Steps" checklist for session setup
- Add CLAUDE.md generation guidance to instructions
- Use Opus model for terraform-review workflow
- Deploy TERRAFORM_MODULE_REQUIREMENTS.md to terraform_module repos
- Remove .pre-commit-config.yaml from requirements (using git hooks instead)
