### PR TITLE
Remove deleted IAM user aleks from trusted_arns

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -64,7 +64,6 @@ module "infrahouse8-github-control" {
     "arn:aws:iam::493370826424:role/ih-tf-aws-control-493370826424-admin"
   ]
   trusted_arns = [
-    local.me_arn
   ]
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,6 @@ locals {
   aws_default_region = "us-west-1"
 
   s_prefix    = "${data.aws_ssm_parameter.gh_secrets_namespace.value}tf_admin"
-  me_arn      = "arn:aws:iam::990466748045:user/aleks"
   environment = "production"
   team_members = {
     "akuzminsky" : [


### PR DESCRIPTION
The IAM user arn:aws:iam::990466748045:user/aleks no longer exists,
causing MalformedPolicyDocument errors on the state-manager role.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
