### PR TITLE
Remove deprecated infrahouse-github-backup configuration

### DIFF
--- a/infrahouse-github-backup.tf
+++ b/infrahouse-github-backup.tf
@@ -1,7 +1,0 @@
-module "infrahouse-github-backup" {
-  providers = {
-    aws = aws.aws-303467602807-uw1
-  }
-  source  = "registry.infrahouse.com/infrahouse/github-backup-configuration/aws"
-  version = "~> 1.0, >=1.0.3"
-}


### PR DESCRIPTION
The backup module referenced a non-existent IAM role
arn:aws:iam::493370826424:role/infrahouse-github-backup,
causing MalformedPolicyDocument errors during apply.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
