### PR TITLE
Add SSO admin role to trusted_arns for local terraform access

### DIFF
--- a/infrahouse8_repos.tf
+++ b/infrahouse8_repos.tf
@@ -64,6 +64,7 @@ module "infrahouse8-github-control" {
     "arn:aws:iam::493370826424:role/ih-tf-aws-control-493370826424-admin"
   ]
   trusted_arns = [
+    "arn:aws:iam::990466748045:role/AWSReservedSSO_AWSAdministratorAccess_16bdbe5eb442e7ef"
   ]
 }
 


### PR DESCRIPTION
## Summary
- After removing the deleted IAM user `aleks` in #242, the `trusted_arns` list was left empty
- This prevents local `terraform init` from assuming the `ih-tf-github-control-state-manager` role in account 289256138624
- Adds the SSO admin role (`AWSReservedSSO_AWSAdministratorAccess`) to restore local access

## Test plan
- [ ] CI plan passes and shows the trust policy update on the state-manager role
- [ ] After merge and apply, verify `terraform init -reconfigure` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)