### PR TITLE
Add HOMEBREW_TAP_TOKEN secret to infrahouse-toolkit

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -55,6 +55,7 @@ locals {
       "description" = "InfraHouse Toolkit."
       "secrets" = {
         "CODACY_PROJECT_TOKEN" = data.aws_secretsmanager_secret_version.codacy_api_token.secret_string
+        "HOMEBREW_TAP_TOKEN"   = module.github-token.secret_value
         "PYPI_API_TOKEN"       = data.aws_secretsmanager_secret_version.pypi_api_token.secret_string
       }
       "type" = "python_app"


### PR DESCRIPTION
The infrahouse-toolkit release workflow needs to send a repository_dispatch
event to homebrew-infrahouse-toolkit to trigger a formula update.
The default GITHUB_TOKEN is scoped to the current repo only and cannot
make API calls to a different repository, so a cross-repo PAT is needed.
