### PR TITLE
Add PAT_TOKEN secret to homebrew-infrahouse-toolkit

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -71,6 +71,9 @@ locals {
     "homebrew-infrahouse-toolkit" = {
       "description" = "Homebrew Formula for infrahouse-toolkit"
       "type"        = "other"
+      "secrets" = {
+        "PAT_TOKEN" = module.github-token.secret_value
+      }
     }
     "infrahouse-website-infra" = {
       "description" = "InfraHouse Website Infrastructure."


### PR DESCRIPTION
## Summary
- Adds `PAT_TOKEN` secret (classic GitHub token) to the `homebrew-infrahouse-toolkit` repository
- PRs created by `peter-evans/create-pull-request` using `GITHUB_TOKEN` don't trigger other workflows (like the vulnerability check), so a PAT is needed instead

## Test plan
- [ ] Verify `PAT_TOKEN` secret is created on the `homebrew-infrahouse-toolkit` repo after apply
- [ ] Update `update-formula.yml` in homebrew-infrahouse-toolkit to use `${{ secrets.PAT_TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}`
- [ ] Trigger a new formula update and confirm the vuln-scanner-pr check runs on the created PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)