### PR TITLE
Replace ANTHROPIC_API_KEY org secret with per-repo secrets

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -532,15 +532,15 @@ module "repos" {
     try(each.value["topics"], [])
   )
   secrets = merge(
+    {
+      ANTHROPIC_API_KEY = module.anthropic_api_key.secret_value
+    },
     contains(keys(each.value), "secrets") ? each.value["secrets"] : {},
-    merge(
-      contains(["terraform_aws", "python_app"], each.value["type"]) ?
-      {
-        AWS_DEFAULT_REGION = local.aws_default_region
-
-      } :
-      {}
-    )
+    contains(["terraform_aws", "python_app"], each.value["type"]) ?
+    {
+      AWS_DEFAULT_REGION = local.aws_default_region
+    } :
+    {}
   )
 }
 

--- a/secrets.tf
+++ b/secrets.tf
@@ -101,8 +101,3 @@ module "anthropic_api_key" {
   ]
 }
 
-resource "github_actions_organization_secret" "anthropic_api_key" {
-  secret_name     = "ANTHROPIC_API_KEY"
-  plaintext_value = module.anthropic_api_key.secret_value
-  visibility      = "all"
-}


### PR DESCRIPTION
GitHub doesn't allow org-level secrets for private repos on our plan.
Move ANTHROPIC_API_KEY to repo-level secrets for all managed repos.
