### PR TITLE
Fix SECURITY.md commit_message drift

### DIFF
--- a/modules/plain-repo/repos-files.tf
+++ b/modules/plain-repo/repos-files.tf
@@ -176,7 +176,7 @@ resource "github_repository_file" "security_md" {
   repository          = github_repository.repo.name
   file                = "SECURITY.md"
   content             = file("${path.module}/files/SECURITY.md")
-  commit_message      = "Add SECURITY.md"
+  commit_message      = "Update SECURITY.md"
   overwrite_on_create = true
 }
 

--- a/repos.tf
+++ b/repos.tf
@@ -359,14 +359,13 @@ locals {
       "topics"        = ["lambda", "serverless", "monitoring"]
     }
     "terraform-aws-org-governance" = {
-      "description"   = <<-EOT
+      "description" = <<-EOT
         Terraform module for centralized AWS Organizations governance deployed
         in the management account, including log retention enforcement, SCPs,
         tag policies, and delegated admin registration.
       EOT
-      "type"          = "terraform_module"
-      "template_repo" = null
-      "topics"        = ["aws-organizations", "governance", "compliance"]
+      "type"        = "terraform_module"
+      "topics"      = ["aws-organizations", "governance", "compliance"]
     }
     "terraform-aws-openvpn" = {
       "description"   = <<-EOT


### PR DESCRIPTION
## Summary
- Update `commit_message` from `"Add SECURITY.md"` to `"Update SECURITY.md"` to match Terraform state and eliminate drift across 48 repos
- Restore `template_repo` for `terraform-aws-org-governance` which was genuinely created from a template

## Context
Depends on #270. After the template drift fix, 49 resources still showed drift — 48 `security_md` resources with a cosmetic `commit_message` mismatch and 1 repo (`org-governance`) that shouldn't have had its template removed.

## Expected plan after both PRs
2 changes: no-op commits to `terraform-aws-org-governance` and `terraform-module-template` to sync their commit_message in state. After that, plans will be clean.

## Test plan
- [ ] CI plan shows only 2 `security_md` commit_message changes (org-governance + template repo)
- [ ] No other drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)