### PR TITLE
Add github-control repo to infrahouse org

### DIFF
--- a/repos.tf
+++ b/repos.tf
@@ -30,6 +30,11 @@ locals {
       "type"          = "other"
       "template_repo" = null
     }
+    "github-control" = {
+      "description"   = "InfraHouse GitHub configuration."
+      "type"          = "other"
+      "template_repo" = null
+    }
     "infrahouse-com" = {
       "description"   = "InfraHouse.com content."
       "type"          = "other"


### PR DESCRIPTION
## Summary
- Adds `github-control` to `local.repos` in `repos.tf` as type `other` with `template_repo = null`
- This creates the repo under the `infrahouse` org via the `plain-repo` module
- First step in migrating github-control from `infrahouse8` personal account to `infrahouse` org

## Follow-up steps (after merge & apply)
- Push git history to the new `infrahouse/github-control`
- Update AWS OIDC trust policies to allow the new repo's CI/CD
- Move `github_actions_variable` resources to target the new repo
- Verify CI/CD works from `infrahouse/github-control`
- Archive `infrahouse8/github-control`

## Test plan
- [ ] CI passes (terraform plan)
- [ ] Review plan output to confirm repo creation with expected settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)